### PR TITLE
PureScript 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 /.spago/
 yarn.lock
 package-lock.json
+generated-docs/

--- a/bower.json
+++ b/bower.json
@@ -1,26 +1,23 @@
 {
-  "name": "purescript-text-encoding",
-  "description": "WHATWG/W3C Encoding Standard",
-  "authors": ["Andreas Schacker", "Alexandra DeWit"],
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/AlexaDeWit/purescript-text-encoding.git"
-  },
-  "keywords": ["purescript", "encode", "decode", "TextEncoder", "TextDecoder"],
-  "ignore": ["**/.*", "node_modules", "bower_components", "test", "tests"],
-  "dependencies": {
-    "purescript-prelude": "^4.0.0",
-    "purescript-functions": "^4.0.0",
-    "purescript-either": "^4.0.0",
-    "purescript-arraybuffer-types": "^2.0.0",
-    "purescript-exceptions": "^4.0.0",
-    "purescript-strings": "^4.0.0"
-  },
-  "devDependencies": {
-    "purescript-console": "^4.0.0",
-    "purescript-strongcheck": "^4.1.1",
-    "purescript-unicode": "^4.0.0",
-    "purescript-partial": "^2.0.0"
-  }
+    "name": "purescript-text-encoding",
+    "license": [
+        "Apache 2.0"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/AlexaDeWit/purescript-text-encoding.git"
+    },
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "output"
+    ],
+    "dependencies": {
+        "purescript-arraybuffer-types": "^v3.0.2",
+        "purescript-either": "^v6.0.0",
+        "purescript-exceptions": "^v6.0.0",
+        "purescript-functions": "^v6.0.0",
+        "purescript-prelude": "^v6.0.0"
+    }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -116,10 +116,9 @@ let additions =
   }
 -------------------------------
 -}
-
-
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.4-20191025/packages.dhall sha256:f9eb600e5c2a439c3ac9543b1f36590696342baedab2d54ae0aa03c9447ce7d4
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220509/packages.dhall
+        sha256:d4c1a03606efdbb7bb7745a9d3aa908cb1ba5611921373659a4c7bf1c41c106c
 
 let overrides = {=}
 

--- a/spago-dev.dhall
+++ b/spago-dev.dhall
@@ -1,0 +1,23 @@
+-- Spago configuration for testing, benchmarking, development.
+--
+-- See:
+-- * ./CONTRIBUTING.md
+-- * https://github.com/purescript/spago#devdependencies-testdependencies-or-in-general-a-situation-with-many-configurations
+--
+
+let conf = ./spago.dhall
+
+in
+
+conf //
+{ sources = [ "src/**/*.purs", "test/**/*.purs", ]
+, dependencies = conf.dependencies #
+	[ "quickcheck"
+	, "console"
+	, "effect"
+	, "psci-support"
+	, "strings"
+	, "unicode"
+	, "arrays"
+  ]
+}

--- a/spago.dhall
+++ b/spago.dhall
@@ -6,20 +6,15 @@ You can edit this file as you like.
     "text-encoding"
 , dependencies =
     [ "arraybuffer-types"
-    , "console"
-    , "effect"
     , "either"
     , "exceptions"
     , "functions"
-    , "partial"
     , "prelude"
-    , "psci-support"
-    , "strings"
-    , "strongcheck"
-    , "unicode"
     ]
 , packages =
     ./packages.dhall
 , sources =
-    [ "src/**/*.purs", "test/**/*.purs" ]
+    [ "src/**/*.purs", ]
+, license = "Apache 2.0"
+, repository = "https://github.com/AlexaDeWit/purescript-text-encoding.git"
 }

--- a/src/Data/TextDecoding.js
+++ b/src/Data/TextDecoding.js
@@ -1,28 +1,9 @@
-'use strict'
+// TextDecoder is a Node.js global starting in v11
+// https://nodejs.org/docs/latest-v11.x/api/globals.html#globals_textdecoder
 
-function importTextEncoding() {
-  try {
-    return require('util').TextDecoder
-  } catch (e) {
-    console.log(
-      'You appear to be trying to use the purescript-text-encoding in a node based ' +
-        'environment that does not support the TextEncoding api introduced in node version 8.3.0. \n' +
-        'It is recommended to update your node environment beyond that to support the necessary api.' +
-        ' if this is not sufficient, please feel free to contact the maintainer of this library via its github here:\n' +
-        'https://github.com/AlexaDeWit/purescript-text-encoding'
-    )
-    throw new Error('TextEncoder could not be imported from node environment')
-  }
-}
-
-// `TextDecoder` is not available in `node`, use polyfill in that case
-var TextDecoder =
-  (typeof window === 'object' && window.TextDecoder) ||
-  (typeof require === 'function' && importTextEncoding())
-
-exports._decode = function(Left, Right, utfLabel, buffer) {
-  var result
-  var decoder = new TextDecoder(utfLabel)
+export function _decode(Left, Right, utfLabel, buffer) {
+  let result
+  let decoder = new TextDecoder(utfLabel)
 
   try {
     result = Right(decoder.decode(buffer))

--- a/src/Data/TextDecoding.purs
+++ b/src/Data/TextDecoding.purs
@@ -1,3 +1,19 @@
+-- | Decode from any `ArrayView` to `String` with the JavaScript
+-- | [__TextDecoder__](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode)
+-- | interface.
+-- |
+-- | #### `USVString` Caveat
+-- |
+-- | The output `String` is a `USVString`, which is essentially
+-- | an array of `CodeUnit`s. This means that if there are any characters
+-- | in the input which are not in the
+-- | [Basic Multilingual Plane](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane)
+-- | then `decode` will fail with `Left Error`.
+-- |
+-- | #### *Node.js* Caveat
+-- |
+-- | The runtime environment
+-- | [*Node.js* only supports Utf8 Encoding](https://nodejs.org/docs/latest-v18.x/api/util.html#class-utiltextdecoder).
 module Data.TextDecoding
   ( Encoding(..)
   , decode

--- a/src/Data/TextEncoding.js
+++ b/src/Data/TextEncoding.js
@@ -1,26 +1,11 @@
-'use strict'
+// TextEncoder is a Node.js global starting in v11
+// https://nodejs.org/docs/latest-v11.x/api/globals.html#globals_textencoder
 
-function importTextEncoding() {
-  try {
-    return require('util').TextEncoder
-  } catch (e) {
-    console.log(
-      'You appear to be trying to use the purescript-text-encoding in a node based ' +
-        'environment that does not support the TextEncoding api introduced in node version 8.3.0. \n' +
-        'It is recommended to update your node environment beyond that to support the necessary api.' +
-        ' if this is not sufficient, please feel free to contact the maintainer of this library via its github here:\n' +
-        'https://github.com/AlexaDeWit/purescript-text-encoding'
-    )
-    throw new Error('TextEncoder could not be imported from node environment')
-  }
-}
-// `TextEncoder` is not available in `node`, use polyfill in that case
-var TextEncoder =
-  (typeof window === 'object' && window.TextEncoder) ||
-  (typeof require === 'function' && importTextEncoding())
+// Node.js only supports UTF-8 encoding.
+// https://nodejs.org/docs/latest-v18.x/api/util.html#class-utiltextencoder
 
-exports._encode = function(utfLabel, str) {
-  var encoder = new TextEncoder(utfLabel)
+export function _encode (utfLabel, str) {
+  let encoder = new TextEncoder(utfLabel)
 
   return encoder.encode(str)
 }

--- a/src/Data/TextEncoding.purs
+++ b/src/Data/TextEncoding.purs
@@ -1,3 +1,19 @@
+-- | Encode from `String` to `Uint8Array` with the JavaScript
+-- | [__TextEncoder__](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode)
+-- | interface.
+-- |
+-- | #### `USVString` Caveat
+-- |
+-- | The input `String` is treated as a `USVString`, which is essentially
+-- | an array of `CodeUnit`s. This means that if there are any characters
+-- | in the `String` which are not in the
+-- | [Basic Multilingual Plane](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane)
+-- | then they will be encoded with the replacement character ‘�’ (`U+FFFD`).
+-- |
+-- | #### *Node.js* Caveat
+-- |
+-- | The runtime environment
+-- | [*Node.js* only supports Utf8 Encoding](https://nodejs.org/docs/latest-v18.x/api/util.html#class-utiltextencoder).
 module Data.TextEncoding
   ( Encoding(..)
   , encode

--- a/test/Test/Encoding.purs
+++ b/test/Test/Encoding.purs
@@ -6,9 +6,8 @@ import Data.TextDecoding (decodeUtf8)
 import Data.TextEncoding (encodeUtf8)
 import Effect (Effect)
 import Effect.Console (log)
-import Partial.Unsafe (unsafePartial)
 import Test.Input
-import Test.StrongCheck (Result, (===), quickCheck)
+import Test.QuickCheck (Result, (===), quickCheck)
 
 testEncoding :: Effect Unit
 testEncoding = do
@@ -21,5 +20,5 @@ testEncoding = do
   -- For well-formed input strings however, the equality holds.
   let
     encodingIdentityProp :: WellFormedInput -> Result
-    encodingIdentityProp (WellFormedInput str) = str === unsafePartial (fromRight <<< decodeUtf8 <<< encodeUtf8 $ str)
+    encodingIdentityProp (WellFormedInput str) = str === (fromRight "" <<< decodeUtf8 <<< encodeUtf8 $ str)
   quickCheck encodingIdentityProp


### PR DESCRIPTION
Upgrade to PureScript 0.15.

Added some module documentation.

Split out the dev dependencies into `spago-dev.dhall`. Run the tests with `spago -x spago-dev.dhall test`.

Thanks for maintaining this package!